### PR TITLE
Include quotes for wiki page rule numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 config.yaml
+Pipfile
+Pipfile.lock
+.vscode/**

--- a/README.rst
+++ b/README.rst
@@ -129,14 +129,14 @@ patrol.
 
       Footer: "If you would like to appeal, please message the moderators. *I am a bot, but this message was generated at the instruction of a human moderator.*"
 
-      Generic:
+      'Generic':
 
           Flair: 'Removed'
 
           Message: |
               Please review our sidebar for the complete list of rules.
 
-      1:
+      '1':
 
           Flair: "Removed (Rule 1)"
 
@@ -144,7 +144,7 @@ patrol.
               Sorry, your post was removed as it breaks rule 1!
               Check our wiki for more info.
 
-      2:
+      '2':
 
           Flair: "Removed (Rule 2)"
 
@@ -159,7 +159,7 @@ patrol.
               - /r/SomeOtherSubreddit - for Y.
               - /r/YetAnotherSubreddit - for Z.
 
-      spam:
+      'spam':
 
           Flair: "Removed (Spam)"
 


### PR DESCRIPTION
Taskerbot does not properly act on rule numbers listed in the wiki page unless they are surrounded by quotes. For example, `1:` will not work, but `'1':` will. This updates the README to reflect that.